### PR TITLE
feat: Add JST to Unix timestamp converter

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -43,6 +43,21 @@
     .converter-section {
       border-top: 1px solid #ddd;
       padding-top: 20px;
+      margin-top: 20px;
+    }
+    .converter-section:first-of-type {
+      border-top: none;
+      padding-top: 0;
+      margin-top: 0;
+    }
+    .datetime-selector select {
+      padding: 6px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 14px;
+    }
+    #convertToUnixButton:hover {
+      background-color: #1976D2;
     }
     input[type="text"] {
       width: 100%;
@@ -74,8 +89,31 @@
   </div>
   
   <div class="converter-section">
+    <h2 style="font-size: 16px; margin: 0 0 15px 0;">Unix → JST 変換</h2>
     <input type="text" id="timestampInput" placeholder="Unixタイムスタンプを入力">
     <div id="result" class="result" style="display: none;"></div>
+  </div>
+  
+  <div class="converter-section">
+    <h2 style="font-size: 16px; margin: 0 0 15px 0;">JST → Unix 変換</h2>
+    <div class="datetime-selector">
+      <div style="display: flex; gap: 5px; margin-bottom: 10px;">
+        <select id="yearSelect" style="flex: 1;"></select>
+        <label style="align-self: center;">年</label>
+        <select id="monthSelect" style="flex: 0.7;"></select>
+        <label style="align-self: center;">月</label>
+        <select id="daySelect" style="flex: 0.7;"></select>
+        <label style="align-self: center;">日</label>
+      </div>
+      <div style="display: flex; gap: 5px; margin-bottom: 10px;">
+        <select id="hourSelect" style="flex: 1;"></select>
+        <label style="align-self: center;">時</label>
+        <select id="minuteSelect" style="flex: 1;"></select>
+        <label style="align-self: center;">分</label>
+      </div>
+      <button id="convertToUnixButton" style="width: 100%; padding: 8px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">Unixタイムスタンプに変換</button>
+      <div id="jstToUnixResult" class="result" style="display: none; margin-top: 10px;"></div>
+    </div>
   </div>
   
   <div class="info">

--- a/popup.js
+++ b/popup.js
@@ -64,3 +64,107 @@ timestampInput.addEventListener('input', () => {
     resultDiv.style.display = 'block';
   }
 });
+
+// JST to Unix timestamp converter
+const yearSelect = document.getElementById('yearSelect');
+const monthSelect = document.getElementById('monthSelect');
+const daySelect = document.getElementById('daySelect');
+const hourSelect = document.getElementById('hourSelect');
+const minuteSelect = document.getElementById('minuteSelect');
+const convertButton = document.getElementById('convertToUnixButton');
+const jstToUnixResult = document.getElementById('jstToUnixResult');
+
+// Initialize date/time selectors with current JST time
+function initializeDateTimeSelectors() {
+  const now = new Date();
+  const jstNow = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Tokyo' }));
+  
+  // Populate year select (current year - 10 to current year + 10)
+  const currentYear = jstNow.getFullYear();
+  for (let year = currentYear - 10; year <= currentYear + 10; year++) {
+    const option = document.createElement('option');
+    option.value = year;
+    option.textContent = year;
+    if (year === currentYear) option.selected = true;
+    yearSelect.appendChild(option);
+  }
+  
+  // Populate month select
+  for (let month = 1; month <= 12; month++) {
+    const option = document.createElement('option');
+    option.value = month;
+    option.textContent = month.toString().padStart(2, '0');
+    if (month === jstNow.getMonth() + 1) option.selected = true;
+    monthSelect.appendChild(option);
+  }
+  
+  // Populate day select
+  updateDaySelect();
+  daySelect.value = jstNow.getDate();
+  
+  // Populate hour select
+  for (let hour = 0; hour < 24; hour++) {
+    const option = document.createElement('option');
+    option.value = hour;
+    option.textContent = hour.toString().padStart(2, '0');
+    if (hour === jstNow.getHours()) option.selected = true;
+    hourSelect.appendChild(option);
+  }
+  
+  // Populate minute select
+  for (let minute = 0; minute < 60; minute++) {
+    const option = document.createElement('option');
+    option.value = minute;
+    option.textContent = minute.toString().padStart(2, '0');
+    if (minute === jstNow.getMinutes()) option.selected = true;
+    minuteSelect.appendChild(option);
+  }
+}
+
+// Update day select based on selected year and month
+function updateDaySelect() {
+  const year = parseInt(yearSelect.value);
+  const month = parseInt(monthSelect.value);
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const currentDay = parseInt(daySelect.value) || 1;
+  
+  daySelect.innerHTML = '';
+  for (let day = 1; day <= daysInMonth; day++) {
+    const option = document.createElement('option');
+    option.value = day;
+    option.textContent = day.toString().padStart(2, '0');
+    if (day === currentDay && day <= daysInMonth) option.selected = true;
+    daySelect.appendChild(option);
+  }
+}
+
+// Update days when year or month changes
+yearSelect.addEventListener('change', updateDaySelect);
+monthSelect.addEventListener('change', updateDaySelect);
+
+// Convert JST to Unix timestamp
+convertButton.addEventListener('click', () => {
+  const year = parseInt(yearSelect.value);
+  const month = parseInt(monthSelect.value) - 1; // JavaScript months are 0-indexed
+  const day = parseInt(daySelect.value);
+  const hour = parseInt(hourSelect.value);
+  const minute = parseInt(minuteSelect.value);
+  
+  // Create date in JST
+  const jstDateStr = `${year}-${(month + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}T${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00+09:00`;
+  const jstDate = new Date(jstDateStr);
+  
+  // Get Unix timestamp (seconds)
+  const unixTimestamp = Math.floor(jstDate.getTime() / 1000);
+  
+  // Display result
+  jstToUnixResult.innerHTML = `
+    <strong>Unix タイムスタンプ (秒):</strong> ${unixTimestamp}<br>
+    <strong>Unix タイムスタンプ (ミリ秒):</strong> ${unixTimestamp * 1000}<br>
+    <small style="color: #666;">JST: ${year}/${(month + 1).toString().padStart(2, '0')}/${day.toString().padStart(2, '0')} ${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:00</small>
+  `;
+  jstToUnixResult.style.display = 'block';
+});
+
+// Initialize on load
+initializeDateTimeSelectors();


### PR DESCRIPTION
## Summary
- Added a new converter feature that allows users to convert JST datetime to Unix timestamp
- Implemented intuitive dropdown selectors for year, month, day, hour, and minute
- Enhanced the popup UI with better section organization and styling

## Changes
1. **UI Updates (popup.html)**:
   - Added new converter section for JST to Unix conversion
   - Implemented dropdown menus for datetime selection
   - Improved section styling with better separation and hover effects

2. **Functionality (popup.js)**:
   - Added JavaScript logic to handle JST to Unix timestamp conversion
   - Initialized datetime selectors with current JST time
   - Dynamic day selection based on selected year/month
   - Display results in both seconds and milliseconds format

## Test plan
- [ ] Test year selector (verify range from current year -10 to +10)
- [ ] Test month/day selector combination (verify correct days for each month)
- [ ] Test leap year handling (February should show 29 days in leap years)
- [ ] Test conversion accuracy with known timestamp values
- [ ] Test UI responsiveness and styling across different window sizes
- [ ] Verify current JST time is correctly set as default values

🤖 Generated with [Claude Code](https://claude.ai/code)